### PR TITLE
Update docker-compose.yaml

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -215,7 +215,7 @@ services:
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
   xilriws-worker:
-    image: ghcr.io/unownhash/xilriws-public:main
+    image: ghcr.io/unownhash/xilriws:main
     restart: unless-stopped
     expose:
     - "5090"


### PR DESCRIPTION
The repository has been moved, ref : https://github.com/UnownHash/Xilriws-Public, now redirects to https://github.com/UnownHash/Xilriws, but the script fails because it cannot find the original endpoint. Updating the file accordingly.